### PR TITLE
scratch3-qrcodeのv1.5への更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ TBD
 - 0.4.3 2020/03/20 Improve Connect function
 
 ### scratch3-qrcode
+- v1.5 2022/03/10 Improve English localization
 - v1.4 2020/05/18 Fix null character issue in binary data.
 - v1.3 2020/05/15 Fix font-size of credit.
 - v1.2 2020/05/14 Add UTF-16 decoder.


### PR DESCRIPTION
[scratch3-qrcode](https://github.com/sugiura-lab/scratch3-qrcode)をv1.5に更新しましたので、デプロイをお願いしたいと思います。

海外書籍のページを見て気づいたのですが、拡張機能一覧の多言語化をしていませんでしたので（ブロックの表記はしていました）、以下のように修正してみました。

- 一部のブロックの英語表記の小文字・大文字を適切に修正
- 拡張機能一覧ページについては、日本語、にほんご、英語で適切に切り替わるように修正（未対応言語は英語表記）

拡張機能一覧ページについては、他の拡張機能を参考に（例えば、[tm2scratch](https://github.com/champierre/tm2scratch)）して、translationMapを拾うようにしつつ、src/containers/extension-library.jsxを置き換える方式としました。
scratch3-qrcodeが単体でセットアップできるようにextension-library.jsxを配置し、セットアップスクリプトで置換するようにしていますが、tm2scratchなどとの同じ方式でやっているものとの競合（結局は同じものを上書きするだけとは思いますが）が少し気になります。
