### PR TITLE
Add LEGO DUPLO Train extension

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,11 @@ jobs:
         with:
           repository: con3office/numberbank
           path: ./numberbank
+      - uses: actions/checkout@v2
+        with:
+          repository: bricklife/scratch-lego-bluetooth-extensions
+          path: ./scratch-lego-bluetooth-extensions
+      - run: sh ./scratch-lego-bluetooth-extensions/scripts/install.sh duplotrain
       - run: sh ./numberbank/install.sh
       - run: sh ./iftttWebhooks/install.sh
       - run: sh ./ic2scratch/install.sh


### PR DESCRIPTION
下記のレゴ製Bluetoothデバイスのための拡張機能セットのうち、LEGO DUPLO Trainのものだけを追加するようにしました。
https://github.com/bricklife/scratch-lego-bluetooth-extensions

拡張機能一覧での多言語化対応は、他の拡張機能で使われている `translationMap` 方式を使う形にしています。また、拡張機能の詳細情報は、下記を参考にjsxファイルをimportする形でやってみました。
https://github.com/tfabworks/xcx-g2s/blob/main/scripts/stretch3-install.sh