### PR TITLE
MicroBit MoreのStretch3用バージョンをチェックアウトする

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: microbit-more/mbit-more-v2
+          ref: stretch3
           path: ./microbitMore
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
MicroBit Moreのmainブランチの最新版をチェックアウトするのはファイルの不整合が起きやすいので、Stretch3用のタグをチェックアウトするように変更しました。
