### PR TITLE
AkaDakoのStretch3用バージョンをチェックアウトする

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: tfabworks/xcx-g2s
+          ref: stretch3
           path: ./xcx-g2s
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
AkaDakoのmainブランチの最新版をチェックアウトするのはファイルの不整合が起きやすいので、Stretch3用のタグをチェックアウトするように変更しました。