### PR TITLE
ChatGPT2Scratch を V2.0 にアップデート

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,4 @@ TBD
 ### ChatGPT2Scratch
 - 2023/03/05 Initial release
 - 2023/03/23 v1.1 Add set-timeout block, set-temperature block, and storing API keys in Session Storage feature.
+- 2023/04/22 v2.0 Added the feature to have contextual conversations, Added "Clear message logs". The release note are [here](https://github.com/ichiroc/chatgpt2scratch/releases/tag/v2.0).


### PR DESCRIPTION
ChatGPT2Scratch を V2.0 にアップデートしました。

新機能
- 文脈を維持した会話をするようにしました
- 会話の文脈をクリアするブロック 「Clear message logs」を追加しました

破壊的変更
複数回メッセージを送信している場合、これまでと変わった応答が返ってきます。
もしもこれまでと同じ結果を得たい場合は、メッセージを送信するたびに「Clear message logs」ブロックを実行してください。

Release note
https://github.com/ichiroc/chatgpt2scratch/releases/tag/v2.0