### PR TITLE
ChatGPT2Scratch を V2.1 にアップデート

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,4 @@ TBD
 - 2023/03/05 Initial release
 - 2023/03/23 v1.1 Add set-timeout block, set-temperature block, and storing API keys in Session Storage feature.
 - 2023/04/22 v2.0 Added the feature to have contextual conversations, Added "Clear message logs". The release note are [here](https://github.com/ichiroc/chatgpt2scratch/releases/tag/v2.0).
+- 2023/05/13 v2.1 Return error message, Change timeout to 30000. The release note are [here](https://github.com/ichiroc/chatgpt2scratch/releases/tag/v2.1).


### PR DESCRIPTION
- [Change timeout to 30000 by ichiroc · Pull Request #10 · ichiroc/chatgpt2scratch](https://github.com/ichiroc/chatgpt2scratch/pull/10)
- [Return error message if OpenAI API returns an error by ichiroc · Pull Request #9 · ichiroc/chatgpt2scratch](https://github.com/ichiroc/chatgpt2scratch/pull/9)