### PR TITLE
add About API Usage fees

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,4 @@ TBD
 - 2023/03/23 v1.1 Add set-timeout block, set-temperature block, and storing API keys in Session Storage feature.
 - 2023/04/22 v2.0 Added the feature to have contextual conversations, Added "Clear message logs". The release note are [here](https://github.com/ichiroc/chatgpt2scratch/releases/tag/v2.0).
 - 2023/05/13 v2.1 Return error message, Change timeout to 30000. The release note are [here](https://github.com/ichiroc/chatgpt2scratch/releases/tag/v2.1).
+- 2023/07/15 v2.1.1 add About API usage fees to README.


### PR DESCRIPTION
@champierre 利用料金に関する情報をREADMEに追加しました。
https://github.com/ichiroc/chatgpt2scratch/

特にデプロイは必要ないですが、Stretch3 のREADMEにも更新を追記しておきました。