### PR TITLE
GAIを追加してください

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,11 +112,17 @@ jobs:
         with:
           repository: yokobond/xcx-arduino
           path: ./xcx-arduino
+      - uses: actions/checkout@v4
+        with:
+          repository: yokobond/xcx-gai
+          ref: stretch3
+          path: ./xcx-gai
       - run: sh ./xcx-arduino/scripts/stretch3-install.sh
       - run: sh ./xcx-webapi/scripts/stretch3-install.sh
       - run: sh ./xcx-screenshot/scripts/stretch3-install.sh
       - run: sh ./xcx-cameraselector/scripts/stretch3-install.sh
       - run: sh ./scratch2webserialapi/install.sh
+      - run: sh ./xcx-gai/scripts/stretch3-install.sh
       - run: sh ./chatgpt2scratch/install.sh
         env:
           AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}

--- a/README.en.md
+++ b/README.en.md
@@ -33,6 +33,7 @@ TM2Scratch and TMPose2Scratch are not compatible, so you cannot use them at the 
 - [Scratch2WebSerialAPI](https://github.com/champierre/scratch2webserialapi/) You can perform serial communication using the Web Serial API from Scratch.
 - [CameraSelector](https://github.com/tfabworks/xcx-cameraselector) This extension enables switching between camera devices for use with Scratch.
 - [Screenshot](https://github.com/tfabworks/xcx-screenshot) This extension allows you to take screenshots of the stage.
+- [GAI (Generative AI)](https://yokobond.github.io/xcx-gai/docs/) This extension allows you to use generative AI from Scratch.
 
 ## How to add a custom extension
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Stretch3は2020年よりオープンソースかつ無料で提供しており�
 - [Screenshot](https://github.com/tfabworks/xcx-screenshot) ステージのスクリーンショットを撮ることができる拡張機能です。
 - [Data Tool](https://github.com/tfabworks/xcx-webapi) 任意のWebAPIにアクセスし、返ってきたJSONデータをパースできる拡張機能です。
 - [Arduino](https://github.com/yokobond/xcx-arduino) ScratchからArduinoを操作できる拡張機能です。
+- [GAI (Generative AI)](https://yokobond.github.io/xcx-gai/docs/ja/) Scratchから生成AIを利用できる拡張機能です。
 
 ## 注意事項
 


### PR DESCRIPTION
Scratchから生成AIを利用できる拡張機能です。

https://yokobond.github.io/xcx-gai/docs/ja/#/

ChatGPTだけでなく、Gemini, Claude, ローカルLLM も利用できる汎用設計になっています。
文字列だけでなく画像、音声を送ったり、生成したりできます。
構造化レスポンス、Function Callsを実装しているので、Scratchの他のプログラムとの連携もできます。

ソースコードは GitHub https://github.com/yokobond/xcx-gai で公開しています。